### PR TITLE
Ensure we link if manager is not linked

### DIFF
--- a/jobs/nessus-agent/templates/bin/link-agent.sh
+++ b/jobs/nessus-agent/templates/bin/link-agent.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # "Grep `nessuscli agent status` for "\[error\]" to prevent relinking all the time
-if /opt/nessus_agent/sbin/nessuscli agent status | grep '\[error\]' || ! /opt/nessus_agent/sbin/nessuscli agent status; then
+if /opt/nessus_agent/sbin/nessuscli agent status | grep '\[error\]' || \
+   /opt/nessus_agent/sbin/nessuscli agent status | grep "Not linked to a manager" || \
+   ! /opt/nessus_agent/sbin/nessuscli agent status; then
     /opt/nessus_agent/sbin/nessuscli agent link \
     --host=<%= p("nessus-agent.server") %> \
     --port=<%= p("nessus-agent.port") %> \


### PR DESCRIPTION
Came across this when I was double-looping across environments on the information super highway.

```shell
some_vm/some_guid: stdout | [warn] [agent] Not linked to a manager
```