### PR TITLE
Add `group` to nessus agent job in README example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ instance_groups:
           key: aaaabbbbbccccddddeeee11112222333
           server: cloud.tenable.com
           port: 443
+          group: mygroup
 ```


### PR DESCRIPTION
This adds the `group` key to the README example

If you leave out `group`, you get the following template rendering error:

```
Task 21443 | 19:26:11 | Preparing deployment: Rendering templates (00:00:00)
                     L Error: Unable to render instance groups for deployment. Errors are:
  - Unable to render jobs for instance group 'nessus-manager'. Errors are:
    - Unable to render templates for job 'nessus-agent'. Errors are:
      - Error filling in template 'link-agent.sh' (line 11: Can't find property '["nessus-agent.group"]')
```