### PR TITLE
Optional proxy arguments for linking agents

### DIFF
--- a/jobs/nessus-agent/spec
+++ b/jobs/nessus-agent/spec
@@ -11,6 +11,14 @@ properties:
     description: "Nessus Server Port"
   nessus-agent.group:
     description: "Nessus Agent Group"
+  nessus-agent.proxy-host:
+    description: "Nessus Proxy Host"
+  nessus-agent.proxy-port:
+    description: "Nessus Proxy Port"
+  nessus-agent.proxy-username:
+    description: "Nessus Proxy Username"
+  nessus-agent.proxy-password:
+    description: "Nessus Proxy Password"
 templates:
   bin/ctl.erb: bin/ctl
   bin/drain: bin/drain

--- a/jobs/nessus-agent/templates/bin/link-agent.sh
+++ b/jobs/nessus-agent/templates/bin/link-agent.sh
@@ -8,6 +8,18 @@ if /opt/nessus_agent/sbin/nessuscli agent status | grep '\[error\]' || \
     --host=<%= p("nessus-agent.server") %> \
     --port=<%= p("nessus-agent.port") %> \
     --key=<%= p("nessus-agent.key") %> \
+    <% if_p('nessus-agent.proxy-host') do |proxy_host| %> \
+    --proxy-host="<%= proxy_host %>" \
+    <% end %> \
+    <% if_p('nessus-agent.proxy-port') do |proxy_port| %> \
+    --proxy-port="<%= proxy_port %>" \
+    <% end %> \
+    <% if_p('nessus-agent.proxy-username') do |proxy_username| %> \
+    --proxy-username="<%= proxy_username %>" \
+    <% end %> \
+    <% if_p('nessus-agent.proxy-password') do |proxy_password| %> \
+    --proxy-password="<%= proxy_password %>" \
+    <% end %> \
     --name=<%= spec.deployment %>-<%= name %>-<%= spec.index %>-<%= p("nessus-agent.group") %> \
     --groups=<%= p("nessus-agent.group") %> || true
 fi


### PR DESCRIPTION
In order to allow agents on bosh deployments hosted in environments requiring to pass through a proxy to link to a manager, this release should support passing through the `--proxy-*` args to the linking agent.

[Based on `nessuscli` agent doc here](https://docs.tenable.com/nessusagent/7_0/Content/NessusCLIAgent.htm)
